### PR TITLE
whid: add rofi support, improve `whid last`

### DIFF
--- a/bin/whid
+++ b/bin/whid
@@ -43,12 +43,19 @@ dmenu)
     # Comment that line if you use vanilla dmenu.
     yPos=$((410-$linesDisplayed*10))
 
-    # Launch dmenu
-    # Comment that line if you use vanilla dmenu, and not one patched with eye candy
-    lineNumber=$(echo "$miniList" | cut -d " " -f 3- | nl -w 3 -n rn | sed -r 's/^([ 0-9]+)[ \t]*(.*)$/\1 - \2/' | dmenu -l 9 -x $left_shift -y $top_shift -w $bar_width -fn 'sans 11' -nb '#201F1D' -nf '#eddec9' -sb '#8F3724' -sf '#EDDEC9' -p 'Hidden:' | cut -d '-' -f -1)
+    
+    # Uncomment only one line with dmenu_cmd
+    # If you use rofi
+    dmenu_cmd="rofi -lines $linesDisplayed -dmenu -p Hidden:"
+    
+    # If you use dmenu, patched with eye candy
+    # dmenu_cmd="dmenu -l 9 -x $left_shift -y $top_shift -w $bar_width -fn sans-11 -nb #201F1D -nf #eddec9 -sb #8F3724 -sf #EDDEC9 -p Hidden:"
+        
+    # If you use vanilla dmenu
+    # dmenu_cmd="dmenu -b -i -l $linesDisplayed -p Hidden:"
 
-    # If you use vanilla dmenu, enable the following line:
-    #lineNumber=$(echo "$miniList" | cut -d " " -f 2- | nl -w 3 -n rn | sed -r 's/^([ 0-9]+)[ \t]*(.*)$/\1 - \2/' | dmenu -b -i -l $linesDisplayed -p 'Hidden:' | cut -d '-' -f -1)
+    # Launch dmenu
+    lineNumber=$(echo "$miniList" | cut -d " " -f 3- | nl -w 3 -n rn | sed -r 's/^([ 0-9]+)[ \t]*(.*)$/\1 - \2/' | $dmenu_cmd | cut -d '-' -f -1)
 
     # If you exited dmenu without selecting anything or if the list was empty
     [ -z "$lineNumber" -o "$miniList" = " Nothing is hidden!" ] && exit
@@ -62,6 +69,8 @@ dmenu)
 last)
     lines=$(wc -l < $file)
     selectedID=$(tail -n 1 $file | cut -d ' ' -f 1)
+    selectedDesktop=$(sed -n "$lines p" $file | cut -d ' ' -f 2)
+    xdotool set_desktop $selectedDesktop
     xdo show $selectedID && sed -i "${lines}d" $file
     ;;
 esac


### PR DESCRIPTION
- Add `dmenu_cmd=...` in order to make it easy to choose rofi, patched dmenu or vanila dmenu.
- Also make `whid last` restore window to proper desktop, as `whid dmenu` does.